### PR TITLE
tell search bots to ignore site altogether.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
hey, could you please prevent search bots from indexing the site? 
otherwise, this will dilute google's and other search engines results with hits from your site, effectively steering users away from thronesdb.com proper. i had a similar situation with a polish-language spin-off of TDB, it was rather painful to correct this after the fact. 
thank you.